### PR TITLE
use `FindR.cmake`, reborrowed from `xtensor-stack/xtensor-r`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,8 @@ macro(xeus_r_create_target target_name linkage output_name)
                                PUBLIC
                                $<BUILD_INTERFACE:${XEUS_R_INCLUDE_DIR}>
                                $<INSTALL_INTERFACE:include>
-                               ${R_INCLUDE_DIR})
+                               ${R_INCLUDE_DIR}
+                               ${R_RCPP_CXXFLAGS})
 
     if (XEUS_R_USE_SHARED_XEUS)
         set(XEUS_R_XEUS_TARGET xeus)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ endif ()
 if (NOT TARGET xeus AND NOT TARGET xeus-static)
     find_package(xeus ${xeus_REQUIRED_VERSION} REQUIRED)
 endif ()
+find_package(R REQUIRED)
 
 # Flags
 # =====
@@ -88,7 +89,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     endif ()
 endif ()
 
-
+include_directories(${R_INCLUDE_DIR} SYSTEM)
 
 # Source files
 # ============

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,8 @@ macro(xeus_r_create_target target_name linkage output_name)
     target_include_directories(${target_name}
                                PUBLIC
                                $<BUILD_INTERFACE:${XEUS_R_INCLUDE_DIR}>
-                               $<INSTALL_INTERFACE:include>)
+                               $<INSTALL_INTERFACE:include>
+                               ${R_INCLUDE_DIR})
 
     if (XEUS_R_USE_SHARED_XEUS)
         set(XEUS_R_XEUS_TARGET xeus)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,12 @@ if (NOT TARGET xeus AND NOT TARGET xeus-static)
 endif ()
 find_package(R REQUIRED)
 
+message(STATUS "R_INCLUDE_DIR    = ${R_INCLUDE_DIR}")
+message(STATUS "R_LDFLAGS        = ${R_LDFLAGS}")
+message(STATUS "R_LIBRARY_BLAS   = ${R_LIBRARY_BLAS}")
+message(STATUS "R_LIBRARY_LAPACK = ${R_LIBRARY_LAPACK}")
+message(STATUS "R_RCPP_CXXFLAGS  = ${R_RCPP_CXXFLAGS}")
+
 # Flags
 # =====
 include(CheckCXXCompilerFlag)
@@ -209,7 +215,8 @@ macro(xeus_r_create_target target_name linkage output_name)
         target_link_libraries(${target_name} PRIVATE "-undefined dynamic_lookup")
     endif ()
     find_package(Threads) # TODO: add Threads as a dependence of xeus-static?
-        target_link_libraries(${target_name} PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+
+    target_link_libraries(${target_name} PRIVATE ${CMAKE_THREAD_LIBS_INIT} ${R_LDFLAGS} ${R_LIBRARY_BLAS} ${R_LIBRARY_LAPACK})
     
 endmacro()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ if (XEUS_R_BUILD_EXECUTABLE)
     target_compile_features(xr PRIVATE cxx_std_17)
     xeus_r_set_common_options(xr)
     xeus_r_set_kernel_options(xr)
-    target_link_libraries(xr PRIVATE xeus-zmq)
+    target_link_libraries(xr PRIVATE xeus-zmq ${R_LDFLAGS} ${R_LIBRARY_BLAS} ${R_LIBRARY_LAPACK})
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     endif ()
 endif ()
 
-include_directories(${R_INCLUDE_DIR} SYSTEM)
-
 # Source files
 # ============
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,6 @@ message(STATUS "R_INCLUDE_DIR    = ${R_INCLUDE_DIR}")
 message(STATUS "R_LDFLAGS        = ${R_LDFLAGS}")
 message(STATUS "R_LIBRARY_BLAS   = ${R_LIBRARY_BLAS}")
 message(STATUS "R_LIBRARY_LAPACK = ${R_LIBRARY_LAPACK}")
-message(STATUS "R_RCPP_CXXFLAGS  = ${R_RCPP_CXXFLAGS}")
 
 # Flags
 # =====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,8 +200,7 @@ macro(xeus_r_create_target target_name linkage output_name)
                                PUBLIC
                                $<BUILD_INTERFACE:${XEUS_R_INCLUDE_DIR}>
                                $<INSTALL_INTERFACE:include>
-                               ${R_INCLUDE_DIR}
-                               ${R_RCPP_CXXFLAGS})
+                               ${R_INCLUDE_DIR})
 
     if (XEUS_R_USE_SHARED_XEUS)
         set(XEUS_R_XEUS_TARGET xeus)

--- a/cmake/FindR.cmake
+++ b/cmake/FindR.cmake
@@ -1,0 +1,88 @@
+# From https://github.com/Kitware/VTK/blob/master/CMake/FindR.cmake
+#
+# - This module locates an installed R distribution.
+#
+# Input:
+#  R_LIB_ARCH - For windows (i386 or x64)
+#
+# Defines the following:
+#  R_COMMAND           - Path to R command
+#  R_HOME              - Path to 'R home', as reported by R
+#  R_INCLUDE_DIR       - Path to R include directory
+#  R_LIBRARY_BASE      - Path to R library
+#  R_LIBRARY_BLAS      - Path to Rblas / blas library
+#  R_LIBRARY_LAPACK    - Path to Rlapack / lapack library
+#  R_LIBRARY_READLINE  - Path to readline library
+#  R_LIBRARIES         - Array of: R_LIBRARY_BASE, R_LIBRARY_BLAS, R_LIBRARY_LAPACK, R_LIBRARY_BASE [, R_LIBRARY_READLINE]
+#
+# Variable search order:
+#   1. Attempt to locate and set R_COMMAND
+#     - If unsuccessful, generate error and prompt user to manually set R_COMMAND
+#   2. Use R_COMMAND to set R_HOME
+#   3. Locate other libraries in the priority:
+#     1. Within a user-built instance of R at R_HOME
+#     2. Within an installed instance of R
+#     3. Within external system libraries
+#
+
+if(NOT R_LIB_ARCH)
+  if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+    set(R_LIB_ARCH x64)
+  else()
+    set(R_LIB_ARCH i386)
+  endif()
+endif()
+
+set(TEMP_CMAKE_FIND_APPBUNDLE ${CMAKE_FIND_APPBUNDLE})
+set(CMAKE_FIND_APPBUNDLE "NEVER")
+find_program(R_COMMAND R DOC "R executable.")
+set(CMAKE_FIND_APPBUNDLE ${TEMP_CMAKE_FIND_APPBUNDLE})
+
+if(R_COMMAND)
+  # temporarily append ".dll" to the cmake find_library suffixes
+  set(OLD_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} ".dll")
+
+  execute_process(WORKING_DIRECTORY .
+                  COMMAND ${R_COMMAND} RHOME
+                  OUTPUT_VARIABLE R_ROOT_DIR
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  # deprecated
+  set(R_HOME ${R_ROOT_DIR} CACHE PATH "R home directory obtained from R RHOME")
+  
+  # /deprecated
+  # the following command does nothing currently, but will be used when deprecated code is removed
+  set(R_HOME ${R_ROOT_DIR} CACHE PATH "R home directory obtained from R RHOME")
+
+  find_path(R_INCLUDE_DIR R.h
+            HINTS ${R_ROOT_DIR} ${R_ROOT_DIR}/bin/${R_LIB_ARCH}
+            PATHS /usr/local/lib /usr/local/lib64 /usr/share
+            PATH_SUFFIXES include R/include
+            DOC "Path to file R.h")
+
+  find_library(R_LIBRARY_BASE R
+            HINTS ${R_ROOT_DIR}/lib ${R_ROOT_DIR}/bin/${R_LIB_ARCH}
+            DOC "R library (example libR.a, libR.dylib, etc.).")
+
+  find_library(R_LIBRARY_BLAS NAMES Rblas blas
+            HINTS ${R_ROOT_DIR}/lib ${R_ROOT_DIR}/bin/${R_LIB_ARCH}
+            DOC "Rblas library (example libRblas.a, libRblas.dylib, etc.).")
+
+  find_library(R_LIBRARY_LAPACK NAMES Rlapack lapack
+            HINTS ${R_ROOT_DIR}/lib ${R_ROOT_DIR}/bin/${R_LIB_ARCH}
+            DOC "Rlapack library (example libRlapack.a, libRlapack.dylib, etc.).")
+
+  find_library(R_LIBRARY_READLINE readline
+            DOC "(Optional) system readline library. Only required if the R libraries were built with readline support.")
+
+  # reset cmake find_library to initial value
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${OLD_SUFFIXES})
+else()
+  message(SEND_ERROR "FindR.cmake requires the following variables to be set: R_COMMAND")
+endif()
+
+# Note: R_LIBRARY_BASE is added to R_LIBRARIES twice; this may be due to circular linking dependencies; needs further investigation
+set(R_LIBRARIES ${R_LIBRARY_BASE} ${R_LIBRARY_BLAS} ${R_LIBRARY_LAPACK} ${R_LIBRARY_BASE})
+if(R_LIBRARY_READLINE)
+  set(R_LIBRARIES ${R_LIBRARIES} ${R_LIBRARY_READLINE})
+endif()

--- a/cmake/FindR.cmake
+++ b/cmake/FindR.cmake
@@ -57,7 +57,6 @@ if(R_COMMAND)
                   COMMAND ${R_COMMAND} CMD config --ldflags
                   OUTPUT_VARIABLE R_LDFLAGS
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
-  string(STRIP ${R_LDFLAGS} R_LDFLAGS)
   set(R_LDFLAGS ${R_LDFLAGS} CACHE PATH "R CMD config --ldflags")
 
   find_path(R_INCLUDE_DIR R.h

--- a/cmake/FindR.cmake
+++ b/cmake/FindR.cmake
@@ -16,7 +16,6 @@
 #  R_LIBRARY_READLINE  - Path to readline library
 #  R_LIBRARIES         - Array of: R_LIBRARY_BASE, R_LIBRARY_BLAS, R_LIBRARY_LAPACK, R_LIBRARY_BASE [, R_LIBRARY_READLINE]
 #  R_LDFLAGS           - R CMD config --ldflags
-#  R_RCPP_CXXFLAGS     - Rscript -e "Rcpp::CxxFlags()"
 #
 # Variable search order:
 #   1. Attempt to locate and set R_COMMAND
@@ -59,12 +58,6 @@ if(R_COMMAND)
                   OUTPUT_VARIABLE R_LDFLAGS
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
   set(R_LDFLAGS ${R_LDFLAGS} CACHE PATH "R CMD config --ldflags")
-
-  execute_process(WORKING_DIRECTORY .
-                  COMMAND ${R_SCRIPT_COMMAND} -e "Rcpp:::CxxFlags()"
-                  OUTPUT_VARIABLE R_RCPP_CXXFLAGS
-                  OUTPUT_STRIP_TRAILING_WHITESPACE)
-  set(R_RCPP_CXXFLAGS ${R_RCPP_CXXFLAGS} CACHE PATH "Rscript -e 'Rcpp::CxxFlags()'")
 
   find_path(R_INCLUDE_DIR R.h
             HINTS ${R_ROOT_DIR} ${R_ROOT_DIR}/bin/${R_LIB_ARCH}

--- a/cmake/FindR.cmake
+++ b/cmake/FindR.cmake
@@ -57,6 +57,7 @@ if(R_COMMAND)
                   COMMAND ${R_COMMAND} CMD config --ldflags
                   OUTPUT_VARIABLE R_LDFLAGS
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(STRIP ${R_LDFLAGS} R_LDFLAGS)
   set(R_LDFLAGS ${R_LDFLAGS} CACHE PATH "R CMD config --ldflags")
 
   find_path(R_INCLUDE_DIR R.h

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,6 +11,7 @@ dependencies:
   - nlohmann_json
   - cppzmq
   - xtl
+  - r-base
   # Test dependencies
   - pytest
   - jupyter_kernel_test>=0.4.3

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,7 +12,6 @@ dependencies:
   - cppzmq
   - xtl
   - r-base
-  - r-rcpp
   # Test dependencies
   - pytest
   - jupyter_kernel_test>=0.4.3

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,6 +12,7 @@ dependencies:
   - cppzmq
   - xtl
   - r-base
+  - r-rcpp
   # Test dependencies
   - pytest
   - jupyter_kernel_test>=0.4.3

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,7 +106,6 @@ int main(int argc, char* argv[])
 
     auto context = xeus::make_context<zmq::context_t>();
 
-    setenv("R_HOME", "/Users/romainfrancois/miniforge3/lib/R", 1);
     Rf_initEmbeddedR(argc, argv);
 
     // Instantiating the xeus xinterpreter

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,8 @@
 #include "xeus-r/xinterpreter.hpp"
 #include "xeus-r/xeus_r_config.hpp"
 
+#define R_NO_REMAP
+#include "Rembedded.h"
 
 #ifdef __GNUC__
 void handler(int sig)
@@ -104,10 +106,12 @@ int main(int argc, char* argv[])
 
     auto context = xeus::make_context<zmq::context_t>();
 
+    setenv("R_HOME", "/Users/romainfrancois/miniforge3/lib/R", 1);
+    Rf_initEmbeddedR(argc, argv);
+
     // Instantiating the xeus xinterpreter
     using interpreter_ptr = std::unique_ptr<xeus_r::interpreter>;
     interpreter_ptr interpreter = interpreter_ptr(new xeus_r::interpreter());
-
 
     std::string connection_filename = extract_filename(argc, argv);
 

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -33,8 +33,8 @@ namespace xeus_r
     }
 
     nl::json interpreter::execute_request_impl(int execution_counter,    // Typically the cell number
-                                               const std::string & code, // Code to execute
-                                               bool silent,
+                                               const std::string & /*code*/, // Code to execute
+                                               bool /*silent*/,
                                                bool /*store_history*/,
                                                nl::json /*user_expressions*/,
                                                bool /*allow_stdin*/)

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -18,6 +18,8 @@
 
 #include "xeus-r/xinterpreter.hpp"
 
+#include "R_ext/Constants.h"
+
 namespace nl = nlohmann;
 
 namespace xeus_r
@@ -41,7 +43,7 @@ namespace xeus_r
         // as third argument.
         // Replace "Hello World !!" by what you want to be displayed under the execution cell
         nl::json pub_data;
-        pub_data["text/plain"] = "Hello World !!";
+        pub_data["text/plain"] = M_PI;
 
         // If silent is set to true, do not publish anything!
         // Otherwise:

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -18,7 +18,9 @@
 
 #include "xeus-r/xinterpreter.hpp"
 
-#include "R_ext/Constants.h"
+#define R_NO_REMAP
+#include "R.h"
+#include "Rinternals.h"
 
 namespace nl = nlohmann;
 
@@ -43,7 +45,10 @@ namespace xeus_r
         // as third argument.
         // Replace "Hello World !!" by what you want to be displayed under the execution cell
         nl::json pub_data;
-        pub_data["text/plain"] = M_PI;
+
+        SEXP msg = PROTECT(Rf_mkString("bonjour"));
+        pub_data["text/plain"] = CHAR(STRING_ELT(msg, 0));
+        UNPROTECT(1);
 
         // If silent is set to true, do not publish anything!
         // Otherwise:

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -32,12 +32,12 @@ namespace xeus_r
         xeus::register_interpreter(this);
     }
 
-    nl::json interpreter::execute_request_impl(int execution_counter, // Typically the cell number
-                                                      const  std::string & /* code */, // Code to execute
-                                                      bool /*silent*/,
-                                                      bool /*store_history*/,
-                                                      nl::json /*user_expressions*/,
-                                                      bool /*allow_stdin*/)
+    nl::json interpreter::execute_request_impl(int execution_counter,    // Typically the cell number
+                                               const std::string & code, // Code to execute
+                                               bool silent,
+                                               bool /*store_history*/,
+                                               nl::json /*user_expressions*/,
+                                               bool /*allow_stdin*/)
     {
         // Use this method for publishing the execution result to the client,
         // this method takes the ``execution_counter`` as first argument,


### PR DESCRIPTION
This borrows `FindR.cmake` from [xtensor-stack/xtensor-r](https://github.com/xtensor-stack/xtensor-r/tree/master) so that we can have `find_package(R REQUIRED)` and `include_directories(${R_INCLUDE_DIR} SYSTEM)` in `CMakeLists.txt`

I'm not sure this is the way, but at least that gives me access to R include files, e.g. `R_ext/Constants.h` so that in `xinterpreter.cpp` I can have `pub_data["text/plain"] = M_PI;`

<img width="471" alt="image" src="https://github.com/jupyter-xeus/xeus-r/assets/2625526/d5d7b2de-a55f-47c8-adb9-b35a96dc27a1">

Again, this probably isn't the way, but I have some cmake + condo tech debt :/ 

I'll follow up with linking to the R libs and calling some code. 