### PR TITLE
evaluate expressions, and `print()` with visibility handling

### DIFF
--- a/include/xeus-r/xinterpreter.hpp
+++ b/include/xeus-r/xinterpreter.hpp
@@ -35,6 +35,8 @@ namespace xeus_r
         interpreter(int argc, char* argv[]);
         virtual ~interpreter() = default;
 
+        std::stringstream capture_stream;
+
     protected:
 
         void configure_impl() override;

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -132,10 +132,10 @@ SEXP try_parse(const std::string& code, int execution_counter) {
                 capture_stream.str("");
                 ptr_R_WriteConsoleEx = capture_WriteConsoleEx;
                 SEXP value = VECTOR_ELT(result, 0);
-                
+
                 R_ToplevelExec([](void* value) {
                     Rf_PrintValue((SEXP)value);
-                }, (void*)value );
+                }, (void*)value);
                 
                 ptr_R_WriteConsoleEx = WriteConsoleEx;
                 

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -27,6 +27,8 @@
 #include "R_ext/Parse.h"
 #include "Rinterface.h"
 
+extern Rboolean R_Visible;
+
 namespace xeus_r {
 
 static interpreter* p_interpreter = nullptr;
@@ -37,6 +39,15 @@ void WriteConsoleEx(const char *buf, int buflen, int otype) {
         p_interpreter->publish_stream("stderr", output);
     } else {
         p_interpreter->publish_stream("stdout", output);
+    }
+}
+
+void capture_WriteConsoleEx(const char *buf, int buflen, int otype) {
+    std::string output(buf, buflen);
+    if (otype == 1) {
+        // do nothing
+    } else {
+        p_interpreter->capture_stream << output;
     }
 }
 
@@ -99,9 +110,6 @@ SEXP try_parse(const std::string& code, int execution_counter) {
                                                nl::json /*user_expressions*/,
                                                bool /*allow_stdin*/)
     {
-
-        nl::json kernel_res;
-
         SEXP parsed = PROTECT(try_parse(code, execution_counter));
         if (Rf_inherits(parsed, "error")) {
             auto err_msg = CHAR(STRING_ELT(VECTOR_ELT(parsed, 0),0));
@@ -111,14 +119,33 @@ SEXP try_parse(const std::string& code, int execution_counter) {
             return xeus::create_error_reply();
         }
 
-        // TODO: wrap in a tryCatch
-        // TODO: eval not just the first, but all
-        SEXP out = PROTECT(Rf_eval(VECTOR_ELT(parsed, 0), R_GlobalEnv));
-        
-        // echo the code for now
-        nl::json pub_data;
-        pub_data["text/plain"] = "bonjour"; // REAL(out)[0];
-        // publish_execution_result(execution_counter, std::move(pub_data), nl::json::object());
+        R_xlen_t n = XLENGTH(parsed);
+        int ErrorOccurred;
+        SEXP smb_withVisible = Rf_install("withVisible");
+            
+        for (R_xlen_t i = 0; i < n; i++) {
+            SEXP expr   = PROTECT(Rf_lang2(smb_withVisible, VECTOR_ELT(parsed, i)));
+            SEXP result = PROTECT(R_tryEval(expr, R_GlobalEnv, &ErrorOccurred));
+            bool visible = LOGICAL(VECTOR_ELT(result, 1))[0];
+
+            if (!ErrorOccurred && visible) {
+                capture_stream.str("");
+                ptr_R_WriteConsoleEx = capture_WriteConsoleEx;
+                SEXP value = VECTOR_ELT(result, 0);
+                
+                R_ToplevelExec([](void* value) {
+                    Rf_PrintValue((SEXP)value);
+                }, (void*)value );
+                
+                ptr_R_WriteConsoleEx = WriteConsoleEx;
+                
+                nl::json pub_data;
+                pub_data["text/plain"] = capture_stream.str();
+                publish_execution_result(execution_counter, std::move(pub_data), nl::json::object());
+            }
+
+            UNPROTECT(2); // expr, result
+        }
 
         UNPROTECT(2); // parsed, out
         


### PR DESCRIPTION
<img width="899" alt="image" src="https://github.com/jupyter-xeus/xeus-r/assets/2625526/1d9c004c-2071-42d4-b99f-d3b9affa79a0">

First take on this. This evaluates each expression, and print them, respecting their visibility, i.e. `cat("hello")` would return `NULL` invisibly and `(cat("hello"))` would return `NULL` visibly: 

<img width="328" alt="image" src="https://github.com/jupyter-xeus/xeus-r/assets/2625526/f1564d41-ff0f-4caf-8182-ffe8551c6401">

internally this uses `Rf_PrintValue()` see here for details https://github.com/r-devel/r-svn/blob/cacdcc725217a01330d1d92c65f8a4b77bef5015/src/main/print.c#L27

so we get the same thing as if it would have been auto printed in the console: 

<img width="797" alt="image" src="https://github.com/jupyter-xeus/xeus-r/assets/2625526/53c05b2d-981a-406a-ac13-1752bbd1f312">

except that there is an extra `\n` between "hello" and "bonjour".

Eventually the idea is to do something else than `print()`ing, if possible in a way that can be extended by third party 📦 . 