### PR TITLE
trim traceback

### DIFF
--- a/share/jupyter/kernels/xr/resources/execute.R
+++ b/share/jupyter/kernels/xr/resources/execute.R
@@ -14,6 +14,7 @@ handle_warning <- function(w) {
 
 handle_error <- function(e) {
   sys_calls <- sys.calls()
+  sys_calls <- head(tail(sys_calls, -16), -3)
   stack <- capture.output(traceback(sys_calls, max.lines = 1L))
 
   evalue <- paste(conditionMessage(e), collapse = "\n")


### PR DESCRIPTION
closes #10 

<img width="410" alt="image" src="https://github.com/jupyter-xeus/xeus-r/assets/2625526/d7657bf0-ceb8-49af-bd68-cbaf894630f5">

also handles `rlang::abort()` kind of errors, except that they include the `.xeus_call() > .. > evaluate() > ` stuff

<img width="745" alt="image" src="https://github.com/jupyter-xeus/xeus-r/assets/2625526/18412080-2de9-400f-a38f-2090232a81ba">
