### PR TITLE
handle newer error in `R_ParseVector()`, i.e. those related to `|>`

### DIFF
--- a/test/test_xr_kernel.py
+++ b/test/test_xr_kernel.py
@@ -36,7 +36,7 @@ class KernelTests(jupyter_kernel_test.KernelTests):
 
     complete_code_samples = ["fun()", "1 + 2", "a %>% b", "a |> b()", "a |> b(c = _)"]
     incomplete_code_samples = ["fun(", "1 + "]
-    invalid_code_samples = ["fun())", "a |> b"]
+    invalid_code_samples = ["fun())", "a |> b", "a |> b(_)", "a |> b(c(_))"]
 
     def test_stdout(self):
         self.flush_channels()

--- a/test/test_xr_kernel.py
+++ b/test/test_xr_kernel.py
@@ -36,7 +36,7 @@ class KernelTests(jupyter_kernel_test.KernelTests):
 
     complete_code_samples = ["fun()", "1 + 2", "a %>% b", "a |> b()", "a |> b(c = _)"]
     incomplete_code_samples = ["fun(", "1 + "]
-    invalid_code_samples = ["fun())"]
+    invalid_code_samples = ["fun())", "a |> b"]
 
     def test_stdout(self):
         self.flush_channels()


### PR DESCRIPTION
The fancy errors coming from invalid `|>` code have to be handled separately. 

closes #38
closes #28 

