### PR TITLE
use console logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ __pycache__
 bld
 .virtual_documents/
 Untitled*.ipynb
+*.log

--- a/share/jupyter/kernels/xr/resources/log.R
+++ b/share/jupyter/kernels/xr/resources/log.R
@@ -1,0 +1,14 @@
+
+logger <- function(level, name) {
+    function(...) {
+        if (isTRUE(getOption('jupyter.log_level') >= level)) {
+            msg <- glue::glue(...)
+            .Call("xeusr_log", name, msg, PACKAGE = "(embedding)")
+        }
+        invisible(NULL)
+    }
+}
+
+log_debug <- logger(3L, 'DEBUG')
+log_info  <- logger(2L, 'INFO')
+log_error <- logger(1L, 'ERROR')

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,7 +103,8 @@ int main(int argc, char* argv[])
 
     auto interpreter = xeus_r::make_interpreter(argc, argv);
     auto hist = xeus::make_in_memory_history_manager();
-    auto logger = xeus::make_console_logger(xeus::xlogger::full);
+    auto logger = xeus::make_console_logger(xeus::xlogger::full, 
+                                            xeus::make_file_logger(xeus::xlogger::content, "xeusr.log"));
 
     std::string connection_filename = extract_filename(argc, argv);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,6 +103,7 @@ int main(int argc, char* argv[])
 
     auto interpreter = xeus_r::make_interpreter(argc, argv);
     auto hist = xeus::make_in_memory_history_manager();
+    auto logger = xeus::make_console_logger(xeus::xlogger::full);
 
     std::string connection_filename = extract_filename(argc, argv);
 
@@ -114,7 +115,8 @@ int main(int argc, char* argv[])
                              std::move(context),
                              std::move(interpreter),
                              xeus::make_xserver_zmq, 
-                             std::move(hist));
+                             std::move(hist), 
+                             std::move(logger));
 
         std::cout <<
             "Starting xr kernel...\n\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,6 +75,15 @@ std::string extract_filename(int argc, char* argv[])
     return res;
 }
 
+std::unique_ptr<xeus::xlogger> make_file_logger(xeus::xlogger::level log_level) {
+    auto logfile = std::getenv("JUPYTER_LOGFILE");
+    if (logfile == nullptr) {
+        return nullptr;
+    }
+
+    return xeus::make_file_logger(log_level, logfile);
+}
+
 int main(int argc, char* argv[])
 {
     if (should_print_version(argc, argv))
@@ -103,8 +112,8 @@ int main(int argc, char* argv[])
 
     auto interpreter = xeus_r::make_interpreter(argc, argv);
     auto hist = xeus::make_in_memory_history_manager();
-    auto logger = xeus::make_console_logger(xeus::xlogger::full, 
-                                            xeus::make_file_logger(xeus::xlogger::content, "xeusr.log"));
+
+    auto logger = xeus::make_console_logger(xeus::xlogger::full, make_file_logger(xeus::xlogger::full));
 
     std::string connection_filename = extract_filename(argc, argv);
 

--- a/src/routines.cpp
+++ b/src/routines.cpp
@@ -91,6 +91,14 @@ SEXP is_complete_request(SEXP code_) {
     return out;
 }
 
+SEXP xeusr_log(SEXP level_, SEXP msg_) {
+    std::string level = CHAR(STRING_ELT(level_, 0));
+    std::string msg = CHAR(STRING_ELT(msg_, 0));
+
+    // TODO: actually do some logging
+    return R_NilValue;
+}
+
 }
 
 void register_r_routines() {
@@ -105,6 +113,7 @@ void register_r_routines() {
         {"xeusr_update_display_data"     , (DL_FUNC) &routines::update_display_data     , 2},
         {"xeusr_clear_output"            , (DL_FUNC) &routines::clear_output            , 1},
         {"xeusr_is_complete_request"     , (DL_FUNC) &routines::is_complete_request     , 1},
+        {"xeusr_log"                     , (DL_FUNC) &routines::xeusr_log               , 2},
 
         {NULL, NULL, 0}
     };


### PR DESCRIPTION
closes #48 

This uses a `xeus::make_console_logger(xeus::xlogger::full)` for now, perhaps later we should use a `xeus::make_file_logger` as well, perhaps based on an R option, e.g. in `IRkernel` : 

```r
#' Kernel logging functions
#'
#' A set of exported logging utilities that have the capability to be used in upstream projects.
#' Log level and log file can be set via R package options e.g. \code{options(jupyter.log_level = 2L)}
#' or from the environment variables JUPYTER_LOG_LEVEL and JUPYTER_LOGFILE.
```