### PR TITLE
`clear_output()`

### DIFF
--- a/share/jupyter/kernels/xr/resources/configure.R
+++ b/share/jupyter/kernels/xr/resources/configure.R
@@ -28,8 +28,10 @@ init_options <- function() {
 }
 
 configure <- function() {
-  attachNamespace("jsonlite")
-  attachNamespace("IRdisplay")
+  pos <- which(search() == "tools:xeusr") 
+
+  attachNamespace("jsonlite", pos = pos + 1)
+  attachNamespace("IRdisplay", pos = pos + 1)
 
   setMethod(jsonlite:::asJSON, "shiny.tag", function(x, ...) {
     jsonlite:::asJSON(as.character(x), ...)

--- a/test/test_xr_kernel.py
+++ b/test/test_xr_kernel.py
@@ -27,7 +27,7 @@ class KernelTests(jupyter_kernel_test.KernelTests):
     ]
 
     # code_page_something = "?cat"
-    # code_clear_output = "clear_output()"
+    code_clear_output = "clear_output()"
     code_generate_error = "stop('ouch')"
     code_inspect_sample = "print"
     


### PR DESCRIPTION
closes #64 

It actually was already implemented, but not called because `IRdisplay` was shadowing `tools:xeusr`