### PR TITLE
Minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 set(XEUS_R_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
-# Versionning
+# Versioning
 # ===========
 
 file(STRINGS "${XEUS_R_INCLUDE_DIR}/xeus-r/xeus_r_config.hpp" version_defines

--- a/include/xeus-r/xeus_r_config.hpp
+++ b/include/xeus-r/xeus_r_config.hpp
@@ -11,7 +11,7 @@
 
 // Project version
 #define XEUS_R_VERSION_MAJOR 0
-#define XEUS_R_VERSION_MINOR 2 
+#define XEUS_R_VERSION_MINOR 2
 #define XEUS_R_VERSION_PATCH 1
 
 // Composing the version string from major, minor and patch

--- a/xeus-rConfig.cmake.in
+++ b/xeus-rConfig.cmake.in
@@ -22,7 +22,10 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
 @XEUS_R_CONFIG_CODE@
 
 include(CMakeFindDependencyMacro)
-find_dependency(xeus-zmq @xeus-zmq_REQUIRED_VERSION@)
+
+if (NOT @XEUS_R_EMSCRIPTEN_WASM_BUILD@)
+    find_dependency(xeus-zmq @xeus-zmq_REQUIRED_VERSION@)
+endif ()
 
 if (NOT TARGET xeus-r AND NOT TARGET xeus-r-static)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Fixes:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    XEUS_R_EMSCRIPTEN_WASM_BUILD
```

and

```
-- Building xeus-r v0..1
```