### PR TITLE
Add post.js to include missing Emscripten APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ if(EMSCRIPTEN)
         PUBLIC "SHELL: --pre-js ../src/env_vars.js"
         PUBLIC "SHELL: -s ERROR_ON_UNDEFINED_SYMBOLS=1"
         PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS='[\"FS\",\"PATH\",\"LDSO\",\"getDylinkMetadata\",\"loadDynamicLibrary\",\"ERRNO_CODES\"]'"
+        PUBLIC "SHELL: --post-js ${CMAKE_CURRENT_SOURCE_DIR}/wasm_patches/post.js"
     )
 endif()
 

--- a/wasm_patches/post.js
+++ b/wasm_patches/post.js
@@ -1,0 +1,12 @@
+if (!('wasmTable' in Module)) {
+    Module.wasmTable = wasmTable
+}
+
+Module.FS = FS
+Module.PATH = PATH
+Module.LDSO = LDSO
+Module.getDylinkMetadata = getDylinkMetadata
+Module.loadDynamicLibrary = loadDynamicLibrary
+
+Module.UTF8ToString = UTF8ToString;
+Module.ERRNO_CODES = ERRNO_CODES;


### PR DESCRIPTION
@anutosh491 I believe you will need something similar in xeus-cpp for it to properly work in JupyterLite with jupyterlite-xeus