### PR TITLE
Specify needed shared libs in kernel spec

### DIFF
--- a/share/jupyter/kernels/xr/kernel.json.in
+++ b/share/jupyter/kernels/xr/kernel.json.in
@@ -6,7 +6,12 @@
       "{connection_file}"
   ],
   "language": "R",
-  "metadata": {"debugger": false},
+  "metadata": {
+    "debugger": false,
+    "shared": {
+      "libRblas.so": "lib/R/lib/libRblas.so"
+    }
+  },
   "env": {
     "R_HOME": "@R_HOME@",
     "LD_LIBRARY_PATH": "@XEUS_R_LD_LIBRARY_PATH@"


### PR DESCRIPTION
In combination with https://github.com/jupyterlite/xeus/pull/146 it allows xeus-r to start in JupyterLite!