### PR TITLE
Fix R ldflags for wasm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,7 @@ macro(xeus_r_create_target target_name linkage output_name)
 
     if (EMSCRIPTEN)
         target_link_libraries(${target_name} PUBLIC ${XEUS_R_XEUS_TARGET}
-            PRIVATE ${R_LIBRARY_BASE} ${R_LIBRARY_BLAS} ${R_LIBRARY_LAPACK} ${R_LDFLAGS})
+            PRIVATE ${R_LIBRARY_BLAS} ${R_LIBRARY_LAPACK} ${R_LDFLAGS})
     else ()
         target_link_libraries(${target_name} PUBLIC ${XEUS_R_XEUS_TARGET} PRIVATE ${R_LIBRARY_BASE})
     endif ()

--- a/cmake/FindR.cmake
+++ b/cmake/FindR.cmake
@@ -87,17 +87,11 @@ if(R_COMMAND)
 
   set(R_HOME ${R_ROOT_DIR} CACHE PATH "R home directory obtained from R RHOME")
 
-  # FIXME: the pre.js needs to be removed from r-base
-  if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    message(STATUS "Setting R_LDFLAGS for Emscripten")
-    set(R_LDFLAGS "-L${CMAKE_PREFIX_PATH}/lib -L${CMAKE_PREFIX_PATH}/lib/R/lib -lRblas -lFortranRuntime -lpcre2-8 -llzma -lbz2 -lz -lrt -ldl -lm -liconv" CACHE STRING "Linker flags for R libraries in Emscripten")
-  else()
-    execute_process(WORKING_DIRECTORY .
-                    COMMAND ${R_COMMAND} CMD config --ldflags
-                    OUTPUT_VARIABLE R_LDFLAGS
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    set(R_LDFLAGS ${R_LDFLAGS} CACHE PATH "R CMD config --ldflags")
-  endif()
+  execute_process(WORKING_DIRECTORY .
+                  COMMAND ${R_COMMAND} CMD config --ldflags
+                  OUTPUT_VARIABLE R_LDFLAGS
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(R_LDFLAGS ${R_LDFLAGS} CACHE PATH "R CMD config --ldflags")
 
   set(R_INCLUDE_DIR "${R_HOME}/include" CACHE PATH "Path to R include directory")
   find_library(R_LIBRARY_BASE R


### PR DESCRIPTION
- The *pre.js* file was removed from `r-base` in https://github.com/emscripten-forge/recipes/pull/1926
- `R_LIBRARY_BASE` is already included in `R_LDFLAGS` and causes duplicate symbol errors when linked twice (this *could* be fixed in `r-base`).