### PR TITLE
fix: render R help as HTML to avoid nroff overstrike

### DIFF
--- a/hera/NAMESPACE
+++ b/hera/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(mime_bundle,default)
 S3method(mime_types,default)
+S3method(mime_types,help_files_with_topic)
 S3method(mime_types,htmlwidget)
 S3method(mime_types,shiny.tag)
 S3method(mime_types,shiny.tag.list)

--- a/hera/R/mime_bundle.R
+++ b/hera/R/mime_bundle.R
@@ -32,6 +32,16 @@ mime_types.shiny.tag <- function(x) {
   c("text/plain", "text/html")
 }
 
+# R help objects. Without this, mime_types.default returns "text/plain", which
+# repr::repr_text renders via tools::Rd2txt. Rd2txt emits nroff overstrike
+# ("_\bX" underline, "X\bX" bold), and Jupyter's stdout stream does not
+# interpret backspaces, so ?lm displays raw "_ l_ m" garbage. Advertising
+# text/html lets the frontend pick the HTML rendering instead.
+#' @export
+mime_types.help_files_with_topic <- function(x) {
+  c("text/plain", "text/html")
+}
+
 #' bundle an object
 #'
 #' @param x an object


### PR DESCRIPTION
## Problem

The help documentation (e.g. `?lm`)  currently has some strange rendering in Jupyter cell output, e.g. `_ F_ i_ t_ t_ i_ n_ g _ L_ i_ n_ e_ a_ r _ M_ o_ d_ e_ l_ s` instead of  _Fitting Linear Models_.

## Cause

Help objects of class `help_files_with_topic` fall through `mime_types.default` and only advertise `text/plain`. `repr::repr_text.help_files_with_topic` then renders them via `tools::Rd2txt`, and the output contains nroff overstrike bytes (`_\bX` for underline, `X\bX` for bold). A real terminal collapses those into styled text, but Jupyter's stdout stream  lets the raw sequences leak through.

## Fix

Admittedly this is just a partial fix, but if we register `mime_types.help_files_with_topic` returning `c("text/plain", "text/html")`. `repr` will render them with `repr_html.help_files_with_topic`, and `IRdisplay::prepare_mimebundle` produces a nice HTML display that the frontend prefers.

## Related Issues

This may relate to or close #34 but it's a sparse issue so I'm not sure