### PR TITLE
fix: install hera via build env to avoid version-skew failures

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -54,27 +54,9 @@ jobs:
           echo "R_HOME=${PREFIX}/lib/R"       > "${BUILD_PREFIX}/lib/R/etc/Makeconf"
           cat "${PREFIX}/lib/R/etc/Makeconf" >> "${BUILD_PREFIX}/lib/R/etc/Makeconf"
 
-          # Dependencies for hera
-          libraries=(
-            jsonlite
-            rlang
-            base64enc
-            digest
-            fastmap
-            htmltools
-            cli
-            glue
-            vctrs
-          )
-
-          for library in "${libraries[@]}"; do
-              # Create a backup
-              echo "Backup $library"
-              mv $PREFIX/lib/R/library/$library/libs/$library.so $PREFIX/lib/R/library/$library/libs/$library.so.bak
-              cp $BUILD_PREFIX/lib/R/library/$library/libs/$library.so $PREFIX/lib/R/library/$library/libs/$library.so
-          done
-
-          ${BUILD_PREFIX}/bin/R CMD INSTALL ./hera --no-byte-compile --no-test-load --library=$PREFIX/lib/R/library/
+          ${BUILD_PREFIX}/bin/R CMD INSTALL ./hera --no-byte-compile --no-test-load --library=${BUILD_PREFIX}/lib/R/library/
+          rm -rf ${PREFIX}/lib/R/library/hera
+          cp -r ${BUILD_PREFIX}/lib/R/library/hera ${PREFIX}/lib/R/library/hera
 
           emcmake cmake . \
             -DCMAKE_BUILD_TYPE=Release                        \
@@ -83,12 +65,6 @@ jobs:
             -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
             -DXEUS_R_EMSCRIPTEN_WASM_BUILD=ON
           emmake make -j ${{ env.ncpus }} install
-
-          # Restore libraries
-          for library in "${libraries[@]}"; do
-              rm $PREFIX/lib/R/library/$library/libs/$library.so
-              mv $PREFIX/lib/R/library/$library/libs/$library.so.bak $PREFIX/lib/R/library/$library/libs/$library.so
-          done
 
       - name: Jupyter Lite integration
         shell: bash -l {0}

--- a/environment-wasm-build.yml
+++ b/environment-wasm-build.yml
@@ -18,6 +18,10 @@ dependencies:
   - r-cli
   - r-glue
   - r-vctrs
+  - r-evaluate
+  - r-IRdisplay
+  - r-r6
+  - r-repr
   # JupyterLite
   - jupyter_server
   - jupyterlite-core


### PR DESCRIPTION
## Summary

`build (Github-page)` currently fails during `R CMD INSTALL ./hera` when conda-forge and emscripten-forge resolve different versions of a shared R package. The existing "swap native `.so` over wasm `.so`" dance leaves the host env's R code mismatched against the swapped-in native `.so`; vctrs' `check_linked_version()` in `.onLoad` aborts lazy-load prep:

> ✖ The DLL version (0.7.3) does not correspond to the package version (0.7.2).

Example failing run: https://github.com/jupyter-xeus/xeus-r/actions/runs/24591420422/job/71970919574

## Fix

`hera` is a pure-R package (no `src/`, no `LinkingTo`), so install it into the build env's own library — where lazy-load dependencies resolve against a single consistent tree — and copy the resulting directory into the host env. This removes ~30 lines of shell and eliminates the entire class of cross-env ABI skew.

## Testing

Reproduced the failure locally by creating fresh envs from this PR's `environment-wasm-*.yml` (both channels still expose the skew today). With the patched logic, `R CMD INSTALL ./hera` completes with `* DONE (hera)`, the rest of the build proceeds, the JupyterLite site loads, and the xr kernel starts in the browser without ABI errors.