### PR TITLE
Emscripten: read R startup profiles instead of --vanilla

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -77,6 +77,8 @@ jobs:
           jupyter lite build \
               --XeusAddon.prefix=${{ env.PREFIX }} \
               --XeusAddon.mounts=${{ env.PREFIX }}/lib/R/library/hera:/lib/R/library/hera \
+              --XeusAddon.mounts=wasm_patches/Rprofile.site:/lib/R/etc \
+              --XeusAddon.mounts=wasm_patches/.Rprofile:/home/web_user \
               --XeusAddon.default_channels=https://repo.prefix.dev/emscripten-forge-4x \
               --XeusAddon.default_channels=https://repo.prefix.dev/conda-forge \
               --contents README.md \

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -78,8 +78,10 @@ interpreter::interpreter(int argc, char* argv[])
     // When building with Emscripten, pass --no-readline to disable
     // readline support, as r-base is not compiled with readline
     // and will not read input from the command line.
+    // The remaining flags are --vanilla without --no-site-file and
+    // --no-init-file, so that Rprofile.site and .Rprofile are still read.
 #ifdef __EMSCRIPTEN__
-    const char* argvNew[] = {"--no-readline", "--vanilla"};
+    const char* argvNew[] = {"--no-readline", "--no-save", "--no-restore", "--no-environ"};
     Rf_initEmbeddedR(sizeof(argvNew) / sizeof(argvNew[0]), const_cast<char**>(argvNew));
 #else
     Rf_initEmbeddedR(argc, argv);

--- a/test/test_xr_kernel.py
+++ b/test/test_xr_kernel.py
@@ -6,6 +6,8 @@
 # The full license is in the file LICENSE, distributed with this software.
 #############################################################################
 
+import os
+import shutil
 import tempfile
 import unittest
 import jupyter_kernel_test
@@ -47,6 +49,50 @@ class KernelTests(jupyter_kernel_test.KernelTests):
         self.assertEqual(len(data), 2, data.keys())
         self.assertIn("<html>", data["text/html"])
         self.assertIn("<h1>hello</h1>", data["text/html"])
+
+
+class StartupProfileTests(jupyter_kernel_test.KernelTests):
+    """The kernel must source R's startup profiles in the documented order:
+    the site profile (Rprofile.site) first, then the user profile (.Rprofile),
+    so the user profile overrides the site profile."""
+
+    kernel_name = "xr"
+    language_name = "R"
+
+    @classmethod
+    def setUpClass(cls):
+        cls._profile_dir = tempfile.mkdtemp()
+        site = os.path.join(cls._profile_dir, "Rprofile.site")
+        user = os.path.join(cls._profile_dir, ".Rprofile")
+        # The site profile sets two options; the user profile overrides only
+        # one of them. A correct load therefore leaves the untouched option at
+        # its site value, which proves *both* files were sourced.
+        with open(site, "w") as fh:
+            fh.write('options(xeusr.startup.a = "site-a", xeusr.startup.b = "site-b")\n')
+        with open(user, "w") as fh:
+            fh.write('options(xeusr.startup.a = "user-a")\n')
+        os.environ["R_PROFILE"] = site
+        os.environ["R_PROFILE_USER"] = user
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        for var in ("R_PROFILE", "R_PROFILE_USER"):
+            os.environ.pop(var, None)
+        shutil.rmtree(cls._profile_dir, ignore_errors=True)
+
+    def test_startup_profiles_loaded_in_order(self):
+        self.flush_channels()
+        reply, output_msgs = self.execute_helper(
+            code='cat(getOption("xeusr.startup.a", "<unset>"),'
+                 ' getOption("xeusr.startup.b", "<unset>"))')
+        out = "".join(m["content"]["text"] for m in output_msgs
+                      if m.get("msg_type") == "stream")
+        # "site-b" proves Rprofile.site was sourced (only it sets b); "user-a"
+        # proves .Rprofile was sourced and overrides the site value. Under
+        # --vanilla both would be "<unset>".
+        self.assertEqual(out, "user-a site-b")
 
 #########################################################################################
 #########################################################################################

--- a/wasm_patches/.Rprofile
+++ b/wasm_patches/.Rprofile
@@ -1,0 +1,5 @@
+# User startup profile for the JupyterLite demo (mounted by
+# deploy-github-page.yml). Sourced after Rprofile.site and overrides it.
+options(
+  xeusr.profile.order = "user"
+)

--- a/wasm_patches/Rprofile.site
+++ b/wasm_patches/Rprofile.site
@@ -1,0 +1,11 @@
+# Site-wide startup profile for the JupyterLite demo (mounted by
+# deploy-github-page.yml). Distributions can mount their own to configure the
+# kernel, e.g. options(repr.plot.width = 8, repr.plot.res = 180).
+#
+# Note: R silently ignores the final line of a startup profile unless it ends
+# with a newline — keep the trailing newline in this file.
+
+options(
+  xeusr.profile.order = "site",  # overridden by .Rprofile: proves load order
+  xeusr.profile.site  = TRUE     # set only here: proves the site file loaded
+)


### PR DESCRIPTION
## What & why

Lets a JupyterLite/WASM distribution configure the R kernel through R's canonical startup files — `Rprofile.site` and the user `.Rprofile` — exactly as on desktop R.

Today the Emscripten build starts R with `--vanilla`, which bundles `--no-site-file` and `--no-init-file`, so R silently ignores both profiles; a distribution has no way to set default `options()` for its kernel. The native branch reads profiles (it forwards `argv`), and so does IRkernel — the WASM build is the outlier. `--vanilla` also looks incidental: it was added in #111 (a `Sys.which` WASM fix) with an empty commit body and no comment; the original Emscripten build used only `--no-readline`.

## Change

`src/xinterpreter.cpp`, Emscripten branch:

```diff
-    const char* argvNew[] = {"--no-readline", "--vanilla"};
+    const char* argvNew[] = {"--no-readline", "--no-save", "--no-restore", "--no-environ"};
```

Per `R --help`, that's exactly `--vanilla` **minus** the two flags that disable the config files:

```
--no-save             Don't save it
--no-restore          Don't restore anything
--no-environ          Don't read the site and user environment files
--no-site-file        Don't read the site-wide Rprofile      <- dropped
--no-init-file        Don't read the user R profile          <- dropped
--vanilla             Combine --no-save, --no-restore, --no-site-file,
                      --no-init-file and --no-environ
```

`--no-save`/`--no-restore` keep a kernel from persisting/restoring a workspace. `--no-environ` is kept — `.Renviron` isn't needed for kernel config (that's `Rprofile.site`), and a browser filesystem is a poor place for the secrets `.Renviron` usually holds.

## Using it (WASM distribution)

Mount the profile(s) into the kernel FS with `jupyterlite-xeus`. `R_HOME` is `/lib/R` and `HOME` is `/home/web_user` (confirm with `R.home("etc")` in the kernel):

```bash
jupyter lite build \
  --XeusAddon.mounts="Rprofile.site:/lib/R/etc" \
  --XeusAddon.mounts=".Rprofile:/home/web_user"
```

or in `jupyter_lite_config.json`:

```json
{ "XeusAddon": { "mounts": ["Rprofile.site:/lib/R/etc", ".Rprofile:/home/web_user"] } }
```

where e.g. `Rprofile.site` is:

```r
options(repr.plot.width = 8, repr.plot.height = 6, repr.plot.res = 180)
```

## Tests

Adds `StartupProfileTests` to `test/test_xr_kernel.py`. The site profile sets two options; the user `.Rprofile` overrides only one, so a correct load leaves the untouched option at its site value — proving **both** files were sourced, in order:

```
Rprofile.site:  options(a = "site-a", b = "site-b")
.Rprofile:      options(a = "user-a")
expected:       getOption(a) == "user-a"   (user overrode site)
                getOption(b) == "site-b"   (site value survived  ->  site was read)
# under --vanilla both are unset
```

This runs in the existing `pytest` CI (native kernel).

The Emscripten branch itself was verified manually: built the WASM kernel from this branch, mounted the two profiles into a JupyterLite kernel, and confirmed `a = "user-a"`, `b = "site-b"` headlessly. A permanent WASM check could be added to `deploy-github-page.yml`, but it would pull in Playwright + a JupyterLite build step (slow), so I've left it out — glad to add it if you'd like the Emscripten path under CI.

## Verification

- `pytest test/test_xr_kernel.py::StartupProfileTests` — passes against a locally-built native kernel.
- WASM kernel built from this branch: `commandArgs()` shows the new flags, and a mounted `Rprofile.site` + `.Rprofile` load with correct precedence (`user-a` / `site-b`), where `--vanilla` ignores them.
