### PR TITLE
fix(ci): strip host-x86 compiler flags from the WASM build

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -42,6 +42,13 @@ jobs:
 
           set -eux
 
+          # The conda compilers export host build flags the wasm toolchain rejects (em++ on
+          # -march=, wasm-ld on GNU-ld options like --sort-common); strip those, keep the rest.
+          _wasm_drop() { sed -E 's/(^| )-m(arch|tune|cpu)=[^ ]*//g'; }
+          export CFLAGS="$(printf %s "${CFLAGS-}"   | _wasm_drop)"
+          export CXXFLAGS="$(printf %s "${CXXFLAGS-}" | _wasm_drop)"
+          export LDFLAGS="$(printf %s "${LDFLAGS-}" | sed -E 's/(^| )-Wl,(--sort-common|--as-needed|--disable-new-dtags|--allow-shlib-undefined|-z,[^ ]*)//g')"
+
           export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-r-wasm-host
           echo "PREFIX=$PREFIX" >> $GITHUB_ENV
           export CMAKE_PREFIX_PATH=$PREFIX


### PR DESCRIPTION
## Problem

`deploy-github-page.yml` fails at the emscripten compile:

```
clang++: error: unsupported option '-march=' for target 'wasm32-unknown-emscripten'
```

The build code hasn't changed. `environment-wasm-build.yml` pins no versions, so the env re-resolves on every run, and an upstream package update broke it.

## Root cause

conda-forge/r-base-feedstock#411 ("[4.5.x] Update compilers", 2026-06-10) changed `r-base` 4.5.3's runtime compiler dependency from the `gcc_impl_linux-64`/`gxx_impl_linux-64` binaries to the `gcc_linux-64`/`gxx_linux-64` activation metapackages. r-base ships a compiler at runtime so `install.packages(type="source")` works. Those activation metapackages also install `activate.d` scripts that export the host compiler's flags.

`environment-wasm-build.yml` depends on `r-base`, so the env now pulls the activation packages. On activation the gcc/gxx scripts set `CFLAGS`/`CXXFLAGS` with `-march=nocona -mtune=haswell` and `LDFLAGS` with GNU-ld options. cmake picks up `CXXFLAGS` and `LDFLAGS`, so `em++` and `wasm-ld` get x86 options they don't support.

The r-base build that flipped it:

| | last green (2026-05) | now (2026-06) |
|---|---|---|
| `r-base` build | `4.5.3 h15dba0b_1` | `4.5.3 h502d0c9_3` |
| compiler dep | `gcc_impl_linux-64` | `gcc_linux-64` (activation) |

## Fix

Right after activation, drop the flags the wasm toolchain rejects:

- `CFLAGS`/`CXXFLAGS`: the CPU-arch flags `-march=`, `-mtune=`, `-mcpu=`
- `LDFLAGS`: the GNU-ld-only options `wasm-ld` doesn't support (`--sort-common`, `--as-needed`, `--disable-new-dtags`, ...)

Everything else is kept. These come from r-base's host compiler and mean nothing to `em++`.

## Verification

Built the step end-to-end in a clean linux env (build env, host env, hera), same as CI:

| build | result |
|---|---|
| without the strip | fails on `-march` at `xinterpreter_wasm.cpp` |
| with the strip | builds clean, produces `xr.js`, `xr.wasm`, `libxeus-r.a` |
